### PR TITLE
Add nut_ups_product var

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,12 +5,13 @@ nut_enabled: true
 # Scan for your UPS's values: `sudo nut-scanner -U`
 nut_ups_name: server-room-rack
 nut_ups_driver: nutdrv_qx
+nut_ups_product: UPS
 nut_ups_description: "Server Room Lowell Power Rack UPS"
 nut_ups_port: auto
-nut_ups_vendorid: '0665'
-nut_ups_productid: '5161'
-nut_ups_bus: '001'
-nut_shutdown_finaldelay: '180'
+nut_ups_vendorid: "0665"
+nut_ups_productid: "5161"
+nut_ups_bus: "001"
+nut_shutdown_finaldelay: "180"
 
 nut_ups_admin_user: admin
 
@@ -31,6 +32,5 @@ nut_ups_admin_user: admin
 nut_client_ups: server-room-rack
 nut_client_server: 10.0.2.10
 nut_client_username: observer
-
 # See config-secrets.yml
 # nut_client_password: OBSERVER_PASSWORD_HERE

--- a/main.yml
+++ b/main.yml
@@ -37,13 +37,13 @@
         marker: "# {mark} ANSIBLE MANAGED BLOCK"
         block: |
           [{{ nut_ups_name }}]
-              driver = {{ nut_ups_driver }}
-              product = UPS
+              driver = "{{ nut_ups_driver }}"
+              product = "{{ nut_ups_product }}"
               desc = "{{ nut_ups_description }}"
-              port = {{ nut_ups_port }}
-              vendorid = {{ nut_ups_vendorid }}
-              productid = {{ nut_ups_productid }}
-              bus = {{ nut_ups_bus }}
+              port = "{{ nut_ups_port }}"
+              vendorid = "{{ nut_ups_vendorid }}"
+              productid = "{{ nut_ups_productid }}"
+              bus = "{{ nut_ups_bus }}"
         state: present
         mode: 0640
       notify: restart nut-server
@@ -51,7 +51,7 @@
     - name: Change UPSD configuration.
       lineinfile:
         path: /etc/nut/upsd.conf
-        regexp: '^LISTEN 0.+'
+        regexp: "^LISTEN 0.+"
         line: "LISTEN 0.0.0.0 3493"
         insertafter: EOF
         state: present
@@ -77,15 +77,15 @@
         mode: 0640
       notify: restart nut-monitor
       with_items:
-        - regexp: '^MONITOR.+'
+        - regexp: "^MONITOR.+"
           line: "MONITOR {{ nut_ups_name }}@localhost 1 {{ nut_ups_admin_user }} {{ nut_ups_admin_password }} primary"
-        - regexp: '^FINALDELAY.+'
+        - regexp: "^FINALDELAY.+"
           line: "FINALDELAY {{ nut_shutdown_finaldelay }}"
 
     - name: Configure NUT mode.
       lineinfile:
         path: /etc/nut/nut.conf
-        regexp: '^MODE.+'
+        regexp: "^MODE.+"
         line: "MODE=netserver"
         state: present
         mode: 0640


### PR DESCRIPTION
This pull request adds the small change proposed in issue #10, where the `ups.conf` variable `product` is set by an ansible variable. This way, if someone has a setup where the command `nut-scanner -U` returns a different value than `UPS` (which is the current hard coded value), he can properly configure it and he won't encounter issues after running the playbook.

Furthermore, double quotes have been added under the task that changes the config under `ups.conf`, since I noticed that the output from the command `nut-scanner -U` returns values in double quotes. This is mostly done for alignment and to just be sure, so that it can be excluded as a potential issue.

Unfortunately, due to how my vscode behaves with the extensions installed (I think with the Ansible extension from Red Hat), all values in single quotes have been automatically turned into double quotes. I hope it's not a problem